### PR TITLE
Add uuid validation

### DIFF
--- a/lib/resty/uuid.lua
+++ b/lib/resty/uuid.lua
@@ -64,16 +64,25 @@ function uuid.generate_time_safe()
 end
 
 function uuid.type(id)
-    return lib.uuid_type(parse(id))
+    local parsed = parse(id)
+    return parsed and lib.uuid_type(parsed)
 end
 
 function uuid.variant(id)
-    return lib.uuid_variant(parse(id))
+    local parsed = parse(id)
+    return parsed and lib.uuid_variant(parsed)
 end
 
 function uuid.time(id)
-    local secs = lib.uuid_time(parse(id), tvl)
-    return tonumber(secs), tonumber(tvl.tv_usec)
+    local parsed = parse(id)
+    if parsed then
+      local secs = lib.uuid_time(parsed, tvl)
+      return tonumber(secs), tonumber(tvl.tv_usec)
+    end
+end
+
+function uuid.is_valid(id)
+    return not not parse(id)
 end
 
 mt.__call = uuid.generate


### PR DESCRIPTION
Functions "uuid.type", "uuid.variant", "uuid.time" don't validate uuid in current version.
So for invalid uuid we get: 

```
worker process ... exited on signal 11 (core dumped)"
```

This pull request fixes this problem. 
Also new function "uuid.is_valid" is added.
