### PR TITLE
fix: load_uuid uses incorrect library naming pattern

### DIFF
--- a/lib/resty/uuid.lua
+++ b/lib/resty/uuid.lua
@@ -86,7 +86,11 @@ local function load_uuid()
   for _, library_name in ipairs(library_names) do
     for _, library_version in ipairs(library_versions) do
       for _, library_extension in ipairs(library_extensions) do
-        local lib = load_lib_from_cpath(library_name .. library_version .. library_extension)
+        local lib = load_lib_from_cpath(library_name .. library_extension .. library_version)
+        if lib then
+          return lib
+        end
+        lib = load_lib_from_cpath(library_name .. library_version .. library_extension)
         if lib then
           return lib
         end
@@ -97,9 +101,19 @@ local function load_uuid()
   -- try to load ada library from normal system path
   for _, library_name in ipairs(library_names) do
     for _, library_version in ipairs(library_versions) do
-      local lib = load_lib(library_name .. library_version)
-      if lib then
-        return lib
+      for _, library_extension in ipairs(library_extensions) do
+        local lib = load_lib(library_name .. library_extension .. library_version)
+        if lib then
+          return lib
+        end
+        lib = load_lib(library_name .. library_version .. library_extension)
+        if lib then
+          return lib
+        end
+        lib = load_lib(library_name .. library_version)
+        if lib then
+          return lib
+        end
       end
     end
   end


### PR DESCRIPTION
The `load_uuid` function attempts to load the UUID library from default system path using incorrect naming patterns, specifically `libuuid.1` (version without `.so` or `.dylib` extension). This fails on most systems because the library file doesn't follow this naming convention. Before version 1.2.0 the library was still loading correctly due to the fallback attempts with `uuid` and `uuid.so.1`. 

This PR fixes the issue by using platform-specific naming patterns:  `libuuid.so.1` for Linux and `libuuid.1.dylib` for macOS.
